### PR TITLE
V0.1.4

### DIFF
--- a/demo/demo-decoration-v1.ts
+++ b/demo/demo-decoration-v1.ts
@@ -17,7 +17,7 @@ export function decorateV1(context: DeclarativeFormContext) {
   decorateWithPolarisComponents(context);
 
   context
-    .where(({pathShort}) => pathShort === 'legalEntity.businessDetails')
+    .where(({path}) => path.toStringShort() === 'legalEntity.businessDetails')
     .replaceWith(SpecialBusinessDetails);
 
   context

--- a/demo/demo-utilities.ts
+++ b/demo/demo-utilities.ts
@@ -3,7 +3,7 @@ import {V2} from './v2';
 
 export function translateLabel(node: SchemaNode) {
   // HACK poorman translator mock
-  const pathEnd = node.path.split('.').reverse()[0] || node.path;
+  const pathEnd = node.path.tail;
   return (
     pathEnd
       // space camel cased chars
@@ -58,6 +58,5 @@ function get(obj, path) {
 }
 
 export function translateLabelsForV2(key: string) {
-  return (node: SchemaNode) =>
-    get(labelsForV2, node.path.split('.').concat(key).filter(Boolean));
+  return (node: SchemaNode) => get(labelsForV2, node.path.add(key).toString());
 }

--- a/source/debug/DebugNode.tsx
+++ b/source/debug/DebugNode.tsx
@@ -35,29 +35,29 @@ export function DebugNode({children, node}: DebugProps) {
       style={style}
     >
       <small style={{color}}>
-        {jsxAttr(node, [
-          'uid',
-          'type',
-          'name',
-          'depth',
-          'path',
-          'pathShort',
-          'pathVariant',
-        ])}
+        {['uid', 'type', 'name', 'depth'].map((key) => (
+          <DebugAttribute key={key} name={key} value={node[key]} />
+        ))}
+        <DebugAttribute name="path" value={node.path.toString()} />
+        <DebugAttribute name="pathShort" value={node.path.toStringShort()} />
+        <DebugAttribute
+          name="pathWithBrackets"
+          value={node.path.toStringShort(true, true)}
+        />
       </small>
       {children}
     </div>
   );
 }
 
-function jsxAttr(node: SchemaNode, attributes: (keyof SchemaNode)[]) {
-  return attributes.map((key: keyof SchemaNode) => (
-    <span key={key} style={{color: 'gray', fontSize: '.5em'}}>
-      {key}=&quot;
+function DebugAttribute({name = '', value = ''}) {
+  return (
+    <span style={{color: 'gray', fontSize: '.5em'}}>
+      {name}=&quot;
       <i>
-        <span style={{color: 'black'}}>{node[key]}</span>
+        <span style={{color: 'black'}}>{value}</span>
       </i>
       &quot;{' '}
     </span>
-  ));
+  );
 }

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,5 +1,5 @@
 export {renderNode, renderNodes} from './utilities/RenderNode';
-export {SchemaNode, Decorator, ValidationError} from './types';
+export {SchemaNode, Decorator, ValidationError, Path} from './types';
 export type {
   NodeKind,
   NodeValue,

--- a/source/types.ts
+++ b/source/types.ts
@@ -265,6 +265,20 @@ export class SchemaNode {
     this.onChange(this.value, false);
   }
 
+  /**
+   * @deprecated use .path.toStringShort() instead
+   */
+  public get pathShort() {
+    return this.path.toStringShort();
+  }
+
+  /**
+   * @deprecated use .path.toStringShort(true) instead
+   */
+  public get pathVariant() {
+    return this.path.toStringShort(true);
+  }
+
   public get uid() {
     return this.path.toString();
   }

--- a/source/types.ts
+++ b/source/types.ts
@@ -196,20 +196,20 @@ export class Path {
   public tail: string;
 
   constructor(
-    name: string = '',
+    name = '',
     segments: PathSegment[] = [],
     {isVariant = false, isList = false} = {},
   ) {
-    if (!name) {
+    if (name) {
+      const tail = new PathSegment(name, isList, isVariant);
+      this.segments = segments.concat(tail);
+      this.head = segments[0]?.toString() || '';
+      this.tail = tail.toString();
+    } else {
       this.segments = [];
       this.tail = '';
       this.head = '';
-      return this;
     }
-    const tail = new PathSegment(name, isList, isVariant);
-    this.segments = segments.concat(tail);
-    this.head = segments[0]?.toString() || '';
-    this.tail = tail.toString();
   }
 
   add(name: string, isList = false, isVariant = false): Path {

--- a/source/utilities/hook.ts
+++ b/source/utilities/hook.ts
@@ -25,11 +25,11 @@ export function useNode(node: SchemaNode) {
   const update = (merge: Partial<typeof state>) =>
     setState({...state, ...merge});
 
-  // FIXME resolve useEffect dependencies so they are not circular
+  // To~do will resolve useEffect dependencies so they are not circular later
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(refreshListItems, [node.value]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(refreshFromContext, [reactContext, node.pathShort]);
+  useEffect(refreshFromContext, [reactContext, node.path]);
 
   function onChange(value: any) {
     update({errors: node.onChange(value)});
@@ -42,7 +42,7 @@ export function useNode(node: SchemaNode) {
   function refreshListItems() {
     if (!node.isList || !Array.isArray(node.value)) return;
     node.value.forEach((child: SchemaNode, newIndex: number) => {
-      child.path = [node.path, newIndex].join('.');
+      child.path = node.path.add(newIndex.toString(), true);
       child.deleteSelf = () => removeListItem(newIndex);
     });
 
@@ -52,7 +52,7 @@ export function useNode(node: SchemaNode) {
   }
 
   function refreshFromContext() {
-    const serverErrorNode = reactContext.errors[node.pathShort];
+    const serverErrorNode = reactContext.errors[node.path.toStringShort()];
     const serverErrors: ValidationError[] = Array.isArray(serverErrorNode)
       ? serverErrorNode.map((error) => new ValidationError('server', {error}))
       : [];

--- a/source/utilities/validators.ts
+++ b/source/utilities/validators.ts
@@ -2,7 +2,7 @@ import {ValidationError, Validator} from '../types';
 
 export function presenceValidator(
   val: any,
-  _options: Validator
+  _options: Validator,
 ): ValidationError | null {
   return (Array.isArray(val) ? val.length : val)
     ? null
@@ -33,7 +33,7 @@ function rubyRegexFromStackOverflow(str: string) {
 
 export function formatValidator(
   val: any,
-  options: Validator
+  options: Validator,
 ): ValidationError | null {
   if (!options.format) {
     return null;
@@ -50,7 +50,7 @@ export function formatValidator(
 
 export function lengthValidator(
   val: string,
-  {maximum, minimum}: Validator
+  {maximum, minimum}: Validator,
 ): ValidationError | null {
   if (maximum && val?.length > maximum) {
     return new ValidationError(`MaximumLength`, {maximum});


### PR DESCRIPTION
to help understanding what the framework is doing, I moved back the
strings used for path, pathShort and PathVariant to a class Path using
PathSegment[] to define the paths and provide helpers with tail and head
as well.

con:
This would create slightly more friction in the decoration process as we
would have to do `where(({path}) => path.toString() === '...')` instead
of just `where(({path}) => path === '...')`